### PR TITLE
Wait for X seconds

### DIFF
--- a/src/openutm_verification/core/clients/flight_blender/flight_blender_client.py
+++ b/src/openutm_verification/core/clients/flight_blender/flight_blender_client.py
@@ -338,12 +338,12 @@ class FlightBlenderClient(BaseBlenderAPIClient):
         states = self._load_telemetry_file(filename)
         return self._submit_telemetry_states_impl(operation_id, states, duration_seconds)
 
-    @scenario_step("Wait 5 seconds")
-    def wait_5_seconds(self) -> None:
-        """Wait for 5 seconds."""
-        logger.info("Waiting for 5 seconds...")
-        time.sleep(5)
-        logger.info("Waited for 5 seconds.")
+    @scenario_step("Wait X seconds")
+    def wait_x_seconds(self, wait_time_seconds:int = 5) -> None:
+        """Wait for a specified number of seconds."""
+        logger.info(f"Waiting for {wait_time_seconds} seconds...")
+        time.sleep(wait_time_seconds)
+        logger.info(f"Waited for {wait_time_seconds} seconds.")
 
 
     @scenario_step("Submit Telemetry")


### PR DESCRIPTION
This PR adds a method to the `flight_blenderclient.py` to wait for 5 seconds, this should help with state changes and waiting before telemetry is submitted. I plan to add additional checks re the start time subsequent PRs