### PR TITLE
Add BlueSky scenario definition support with YAML/JSON integration

### DIFF
--- a/config/edmonton/bluesky_a1_head_on.yaml
+++ b/config/edmonton/bluesky_a1_head_on.yaml
@@ -1,0 +1,36 @@
+name: "A1 Head-On Approach (Cooperative)"
+description: >
+  ASTM F3442 Category A1 - Head-On scenario.
+  Edmonton Area B (suburban): Ownship at 53.5200, -113.6000 heading East.
+  Intruder INTA1 (Cessna 172) starts at 53.5200, -113.5500 heading West.
+  Initial separation: ~4.2 km horizontal, 22 m vertical.
+
+display:
+  pan: [53.5200, -113.5750]
+  trails: true
+  reso: false
+  rtf: 10
+
+areas:
+  - name: EDM_A1_BOX
+    color: [0, 255, 0]
+    bounds:
+      - [53.5100, -113.6100]
+      - [53.5100, -113.5400]
+      - [53.5300, -113.5400]
+      - [53.5300, -113.6100]
+
+aircraft:
+  - callsign: INTA1
+    type: C172
+    lat: 53.5200
+    lon: -113.5500
+    heading: 270
+    altitude_ft: 400
+    speed_kts: 87
+    waypoints:
+      - [53.5200, -113.5750]
+      - [53.5200, -113.6000]
+      - [53.5200, -113.6200]
+
+hold_time: "00:02:00.00"

--- a/config/edmonton/bluesky_b2_staggered.yaml
+++ b/config/edmonton/bluesky_b2_staggered.yaml
@@ -1,0 +1,65 @@
+name: "B2 Three Intruders, Staggered Arrival (Cooperative)"
+description: >
+  ASTM F3442 Category B2 - Staggered arrival scenario.
+  Edmonton Area: Ownship hovering at 53.5500 N, -113.5500 W, 100 m AGL (328 ft).
+  Staggered creation to test prioritization with different alert levels:
+    T=0:  INTB2A (Cessna 172)  from East  - ADVISORY only (90 m vertical offset)
+    T=20: INTB2C (Bell 429)    from South - CAUTION max  (50 m vertical offset)
+    T=40: INTB2B (Piper PA-28) from North - WARNING      (7 m vertical offset)
+
+display:
+  pan: [53.5500, -113.5500]
+  trails: true
+  reso: false
+  rtf: 10
+
+areas:
+  - name: EDM_B2_BOX
+    color: [0, 255, 0]
+    bounds:
+      - [53.5100, -113.5800]
+      - [53.5100, -113.4800]
+      - [53.5900, -113.4800]
+      - [53.5900, -113.5800]
+
+aircraft:
+  # T=0: INT-C01 (Early arrival) - Cessna 172 from East, ADVISORY only
+  - callsign: INTB2A
+    type: C172
+    lat: 53.5500
+    lon: -113.5000
+    heading: 270
+    altitude_ft: 623
+    speed_kts: 78
+    start_time: "00:00:00.00"
+    waypoints:
+      - [53.5500, -113.5500]
+      - [53.5500, -113.6000]
+
+  # T=20: INT-C06 (Medium arrival) - Bell 429 from South, CAUTION max
+  - callsign: INTB2C
+    type: B206
+    lat: 53.5200
+    lon: -113.5500
+    heading: 0
+    altitude_ft: 492
+    speed_kts: 78
+    start_time: "00:00:20.00"
+    waypoints:
+      - [53.5500, -113.5500]
+      - [53.5800, -113.5500]
+
+  # T=40: INT-C02 (Late arrival) - Piper PA-28 from North, WARNING
+  - callsign: INTB2B
+    type: P28A
+    lat: 53.5800
+    lon: -113.5500
+    heading: 180
+    altitude_ft: 351
+    speed_kts: 97
+    start_time: "00:00:40.00"
+    waypoints:
+      - [53.5500, -113.5500]
+      - [53.5200, -113.5500]
+
+hold_time: "00:03:30.00"

--- a/src/openutm_verification/core/clients/air_traffic/blue_sky_client.py
+++ b/src/openutm_verification/core/clients/air_traffic/blue_sky_client.py
@@ -18,6 +18,7 @@ from openutm_verification.core.clients.air_traffic.base_client import (
     BaseBlueSkyAirTrafficClient,
     BlueSkyAirTrafficSettings,
 )
+from openutm_verification.core.clients.air_traffic.bluesky_scenario import resolve_scn_path
 from openutm_verification.core.clients.flight_blender.base_client import (
     BaseBlenderAPIClient,
 )
@@ -55,9 +56,13 @@ class BlueSkyClient(BaseBlueSkyAirTrafficClient, BaseBlenderAPIClient):
             time-series sampled at 1 Hz.
         """
 
-        scn_path = config_path or self.settings.simulation_config_path
-        if scn_path:
-            scn_path = str(Path(scn_path).expanduser().resolve())
+        raw_path = config_path or self.settings.simulation_config_path
+        if not raw_path:
+            raise ValueError("No scenario path provided. Provide config_path or set settings.simulation_config_path.")
+
+        # Auto-convert YAML/JSON scenario definitions to a .scn file
+        resolved_path, is_temp_scn = resolve_scn_path(str(Path(raw_path).expanduser().resolve()))
+        scn_path = resolved_path
         duration_s = int(duration or self.settings.simulation_duration or 30)
 
         sensor_ids = self.settings.sensor_ids
@@ -70,89 +75,90 @@ class BlueSkyClient(BaseBlueSkyAirTrafficClient, BaseBlenderAPIClient):
             logger.error(f"Invalid sensor ID in configuration, it should be a valid UUID: {exc}")
             raise
 
-        if not scn_path:
-            raise ValueError("No scenario path provided. Provide config_path or set settings.simulation_config_path.")
-
         # ---- Init BlueSky headless ----
         # detached=True prevents UI/event loop from blocking.
         # Use a temporary directory for BlueSky working files to avoid polluting ~/bluesky
         # BlueSky's pathfinder.init() auto-creates required subdirs (scenario, plugins, output, cache)
-        with tempfile.TemporaryDirectory(prefix="openutm-bluesky-") as tmp_dir:
-            cfg_path = os.path.join(tmp_dir, "settings.cfg")
-            bs.init(mode="sim", detached=True, workdir=tmp_dir, configfile=cfg_path)
+        try:
+            with tempfile.TemporaryDirectory(prefix="openutm-bluesky-") as tmp_dir:
+                cfg_path = os.path.join(tmp_dir, "settings.cfg")
+                bs.init(mode="sim", detached=True, workdir=tmp_dir, configfile=cfg_path)
 
-            # Route console output to stdout (useful for debugging stack commands)
-            bs.scr = ScreenDummy()
-            now = arrow.now()
-            logger.info(f"Initializing BlueSky (headless) and loading scenario: {relative_path(scn_path)} with duration {duration_s}s")
+                # Route console output to stdout (useful for debugging stack commands)
+                bs.scr = ScreenDummy()
+                now = arrow.now()
+                logger.info(f"Initializing BlueSky (headless) and loading scenario: {relative_path(scn_path)} with duration {duration_s}s")
 
-            # ---- Load scenario ----
-            # BlueSky scenario files (like scenario/DEMO/bluesky_flight.scn) are typically loaded with IC.
-            # NOTE: Use absolute paths if relative paths cause issues inside Docker.
-            bs.stack.stack(f"IC {scn_path}")
+                # ---- Load scenario ----
+                # BlueSky scenario files (like scenario/DEMO/bluesky_flight.scn) are typically loaded with IC.
+                # NOTE: Use absolute paths if relative paths cause issues inside Docker.
+                bs.stack.stack(f"IC {scn_path}")
 
-            # Ensure 1 Hz stepping; FF starts fast-time running mode, but we will still step manually.
-            # Some setups work fine with DT 1 and calling bs.sim.step().
-            bs.stack.stack("DT 1.0")
+                # Ensure 1 Hz stepping; FF starts fast-time running mode, but we will still step manually.
+                # Some setups work fine with DT 1 and calling bs.sim.step().
+                bs.stack.stack("DT 1.0")
 
-            # ---- Sample data at 1 Hz for duration_s seconds ----
-            # Store per-aircraft series
-            results_by_acid: dict[str, list[FlightObservationSchema]] = {}
+                # ---- Sample data at 1 Hz for duration_s seconds ----
+                # Store per-aircraft series
+                results_by_acid: dict[str, list[FlightObservationSchema]] = {}
 
-            for t in range(1, duration_s + 1):
-                # Advance sim by one step (DT=1 sec)
-                bs.sim.step()
-                timestamp = now.shift(seconds=t)
-                timestamp_microseconds = int(timestamp.float_timestamp * 1_000_000)  # microseconds
+                for t in range(1, duration_s + 1):
+                    # Advance sim by one step (DT=1 sec)
+                    bs.sim.step()
+                    timestamp = now.shift(seconds=t)
+                    timestamp_microseconds = int(timestamp.float_timestamp * 1_000_000)  # microseconds
 
-                # Snapshot traffic arrays
-                acids: list[str] = list(getattr(bs.traf, "id", []))
-                lats: list[float] = _tolist(getattr(bs.traf, "lat", []))
-                lons: list[float] = _tolist(getattr(bs.traf, "lon", []))
-                alts: list[float] = _tolist(getattr(bs.traf, "alt", []))
-                ground_speeds: list[float] = _tolist(getattr(bs.traf, "gs", []))
-                headings: list[float] = _tolist(getattr(bs.traf, "hdg", []))
-                vertical_speeds: list[float] = _tolist(getattr(bs.traf, "vs", []))
+                    # Snapshot traffic arrays
+                    acids: list[str] = list(getattr(bs.traf, "id", []))
+                    lats: list[float] = _tolist(getattr(bs.traf, "lat", []))
+                    lons: list[float] = _tolist(getattr(bs.traf, "lon", []))
+                    alts: list[float] = _tolist(getattr(bs.traf, "alt", []))
+                    ground_speeds: list[float] = _tolist(getattr(bs.traf, "gs", []))
+                    headings: list[float] = _tolist(getattr(bs.traf, "hdg", []))
+                    vertical_speeds: list[float] = _tolist(getattr(bs.traf, "vs", []))
 
-                for i, acid in enumerate(acids):
-                    lat = float(lats[i])
-                    lon = float(lons[i])
-                    alt_m_or_ft = float(alts[i])
+                    for i, acid in enumerate(acids):
+                        lat = float(lats[i])
+                        lon = float(lons[i])
+                        alt_m_or_ft = float(alts[i])
 
-                    # BlueSky typically uses meters internally for alt, but some scenarios use FL/ft inputs.
-                    # We store altitude_mm as "millimeters"; keep it consistent with your schema.
-                    # If alt is actually feet, you can convert here: alt_m = alt_ft * 0.3048
-                    altitude_mm = alt_m_or_ft * 1000.0
+                        # BlueSky typically uses meters internally for alt, but some scenarios use FL/ft inputs.
+                        # We store altitude_mm as "millimeters"; keep it consistent with your schema.
+                        # If alt is actually feet, you can convert here: alt_m = alt_ft * 0.3048
+                        altitude_mm = alt_m_or_ft * 1000.0
 
-                    # Assign sensor ID: randomly select from list if multiple sensors, otherwise use first
-                    selected_sensor_id = random.choice(sensor_ids) if use_multiple_sensors and len(sensor_ids) > 1 else sensor_ids[0]
-                    metadata = {"sensor_id": str(selected_sensor_id)} if selected_sensor_id else {}
-                    # Include kinematics so the DAA system can coast intruder tracks
-                    metadata["current_state"] = {
-                        "speed": float(ground_speeds[i]) if i < len(ground_speeds) else 0.0,
-                        "track": float(headings[i]) if i < len(headings) else 0.0,
-                        "vertical_speed": float(vertical_speeds[i]) if i < len(vertical_speeds) else 0.0,
-                    }
+                        # Assign sensor ID: randomly select from list if multiple sensors, otherwise use first
+                        selected_sensor_id = random.choice(sensor_ids) if use_multiple_sensors and len(sensor_ids) > 1 else sensor_ids[0]
+                        metadata = {"sensor_id": str(selected_sensor_id)} if selected_sensor_id else {}
+                        # Include kinematics so the DAA system can coast intruder tracks
+                        metadata["current_state"] = {
+                            "speed": float(ground_speeds[i]) if i < len(ground_speeds) else 0.0,
+                            "track": float(headings[i]) if i < len(headings) else 0.0,
+                            "vertical_speed": float(vertical_speeds[i]) if i < len(vertical_speeds) else 0.0,
+                        }
 
-                    obs = FlightObservationSchema(
-                        lat_dd=lat,
-                        lon_dd=lon,
-                        altitude_mm=altitude_mm,
-                        traffic_source=0,
-                        source_type=0,
-                        icao_address=acid,
-                        timestamp=timestamp_microseconds,
-                        metadata=metadata,
-                    )
-                    results_by_acid.setdefault(acid, []).append(obs)
+                        obs = FlightObservationSchema(
+                            lat_dd=lat,
+                            lon_dd=lon,
+                            altitude_mm=altitude_mm,
+                            traffic_source=0,
+                            source_type=0,
+                            icao_address=acid,
+                            timestamp=timestamp_microseconds,
+                            metadata=metadata,
+                        )
+                        results_by_acid.setdefault(acid, []).append(obs)
 
-                    logger.debug(f"{acid:>6} lat={lat:.6f} lon={lon:.6f} alt_mm={altitude_mm:.1f}")
+                        logger.debug(f"{acid:>6} lat={lat:.6f} lon={lon:.6f} alt_mm={altitude_mm:.1f}")
 
-            # Flatten dict -> list[FlightObservationSchema] with stable ordering
-            all_obs: list[FlightObservationSchema] = []
-            for acid in sorted(results_by_acid.keys()):
-                all_obs.extend(results_by_acid[acid])
-            return all_obs
+                # Flatten dict -> list[FlightObservationSchema] with stable ordering
+                all_obs: list[FlightObservationSchema] = []
+                for acid in sorted(results_by_acid.keys()):
+                    all_obs.extend(results_by_acid[acid])
+                return all_obs
+        finally:
+            if is_temp_scn:
+                Path(scn_path).unlink(missing_ok=True)
 
     @internal_step("Generate BlueSky Simulation Air Traffic Data with latency issues", phase=FlightPhase.PRE_FLIGHT)
     async def generate_bluesky_sim_air_traffic_data_with_sensor_latency_issues(
@@ -162,9 +168,13 @@ class BlueSkyClient(BaseBlueSkyAirTrafficClient, BaseBlenderAPIClient):
     ) -> list[FlightObservationSchema]:
         """This method generates"""
 
-        scn_path = config_path or self.settings.simulation_config_path
-        if scn_path:
-            scn_path = str(Path(scn_path).expanduser().resolve())
+        raw_path = config_path or self.settings.simulation_config_path
+        if not raw_path:
+            raise ValueError("No scenario path provided. Provide config_path or set settings.simulation_config_path.")
+
+        # Auto-convert YAML/JSON scenario definitions to a .scn file
+        resolved_path, is_temp_scn = resolve_scn_path(str(Path(raw_path).expanduser().resolve()))
+        scn_path = resolved_path
         duration_s = int(duration or self.settings.simulation_duration or 30)
 
         sensor_ids = self.settings.sensor_ids
@@ -177,88 +187,89 @@ class BlueSkyClient(BaseBlueSkyAirTrafficClient, BaseBlenderAPIClient):
             logger.error(f"Invalid sensor ID in configuration, it should be a valid UUID: {exc}")
             raise
 
-        if not scn_path:
-            raise ValueError("No scenario path provided. Provide config_path or set settings.simulation_config_path.")
-
         # ---- Init BlueSky headless ----
         # detached=True prevents UI/event loop from blocking.
         # Use a temporary directory for BlueSky working files to avoid polluting ~/bluesky
         # BlueSky's pathfinder.init() auto-creates required subdirs (scenario, plugins, output, cache)
         flight_observations: list[FlightObservationSchema] = []
-        with tempfile.TemporaryDirectory(prefix="openutm-bluesky-") as tmp_dir:
-            cfg_path = os.path.join(tmp_dir, "settings.cfg")
-            bs.init(mode="sim", detached=True, workdir=tmp_dir, configfile=cfg_path)
+        try:
+            with tempfile.TemporaryDirectory(prefix="openutm-bluesky-") as tmp_dir:
+                cfg_path = os.path.join(tmp_dir, "settings.cfg")
+                bs.init(mode="sim", detached=True, workdir=tmp_dir, configfile=cfg_path)
 
-            # Route console output to stdout (useful for debugging stack commands)
-            bs.scr = ScreenDummy()
-            now = arrow.now()
-            logger.info(f"Initializing BlueSky (headless) and loading scenario: {relative_path(scn_path)} with duration {duration_s}s")
+                # Route console output to stdout (useful for debugging stack commands)
+                bs.scr = ScreenDummy()
+                now = arrow.now()
+                logger.info(f"Initializing BlueSky (headless) and loading scenario: {relative_path(scn_path)} with duration {duration_s}s")
 
-            # ---- Load scenario ----
-            # BlueSky scenario files (like scenario/DEMO/bluesky_flight.scn) are typically loaded with IC.
-            # NOTE: Use absolute paths if relative paths cause issues inside Docker.
-            bs.stack.stack(f"IC {scn_path}")
+                # ---- Load scenario ----
+                # BlueSky scenario files (like scenario/DEMO/bluesky_flight.scn) are typically loaded with IC.
+                # NOTE: Use absolute paths if relative paths cause issues inside Docker.
+                bs.stack.stack(f"IC {scn_path}")
 
-            # Ensure 1 Hz stepping; FF starts fast-time running mode, but we will still step manually.
-            # Some setups work fine with DT 1 and calling bs.sim.step().
-            bs.stack.stack("DT 1.0")
+                # Ensure 1 Hz stepping; FF starts fast-time running mode, but we will still step manually.
+                # Some setups work fine with DT 1 and calling bs.sim.step().
+                bs.stack.stack("DT 1.0")
 
-            # ---- Sample data at 1 Hz for duration_s seconds ----
-            # Store per-aircraft series
-            results_by_acid: dict[str, list[FlightObservationSchema]] = {}
+                # ---- Sample data at 1 Hz for duration_s seconds ----
+                # Store per-aircraft series
+                results_by_acid: dict[str, list[FlightObservationSchema]] = {}
 
-            for t in range(1, duration_s + 1):
-                # Advance sim by one step (DT=1 sec)
-                bs.sim.step()
-                timestamp = now.shift(seconds=t)
-                timestamp_microseconds = int(timestamp.float_timestamp * 1_000_000)  # microseconds
+                for t in range(1, duration_s + 1):
+                    # Advance sim by one step (DT=1 sec)
+                    bs.sim.step()
+                    timestamp = now.shift(seconds=t)
+                    timestamp_microseconds = int(timestamp.float_timestamp * 1_000_000)  # microseconds
 
-                # Snapshot traffic arrays
-                acids: list[str] = list(getattr(bs.traf, "id", []))
-                lats: list[float] = _tolist(getattr(bs.traf, "lat", []))
-                lons: list[float] = _tolist(getattr(bs.traf, "lon", []))
-                alts: list[float] = _tolist(getattr(bs.traf, "alt", []))
-                ground_speeds: list[float] = _tolist(getattr(bs.traf, "gs", []))
-                headings: list[float] = _tolist(getattr(bs.traf, "hdg", []))
-                vertical_speeds: list[float] = _tolist(getattr(bs.traf, "vs", []))
+                    # Snapshot traffic arrays
+                    acids: list[str] = list(getattr(bs.traf, "id", []))
+                    lats: list[float] = _tolist(getattr(bs.traf, "lat", []))
+                    lons: list[float] = _tolist(getattr(bs.traf, "lon", []))
+                    alts: list[float] = _tolist(getattr(bs.traf, "alt", []))
+                    ground_speeds: list[float] = _tolist(getattr(bs.traf, "gs", []))
+                    headings: list[float] = _tolist(getattr(bs.traf, "hdg", []))
+                    vertical_speeds: list[float] = _tolist(getattr(bs.traf, "vs", []))
 
-                for i, acid in enumerate(acids):
-                    lat = float(lats[i])
-                    lon = float(lons[i])
-                    alt_m_or_ft = float(alts[i])
+                    for i, acid in enumerate(acids):
+                        lat = float(lats[i])
+                        lon = float(lons[i])
+                        alt_m_or_ft = float(alts[i])
 
-                    # BlueSky typically uses meters internally for alt, but some scenarios use FL/ft inputs.
-                    # We store altitude_mm as "millimeters"; keep it consistent with your schema.
-                    # If alt is actually feet, you can convert here: alt_m = alt_ft * 0.3048
-                    altitude_mm = alt_m_or_ft * 1000.0
+                        # BlueSky typically uses meters internally for alt, but some scenarios use FL/ft inputs.
+                        # We store altitude_mm as "millimeters"; keep it consistent with your schema.
+                        # If alt is actually feet, you can convert here: alt_m = alt_ft * 0.3048
+                        altitude_mm = alt_m_or_ft * 1000.0
 
-                    # Assign sensor ID: randomly select from list if multiple sensors, otherwise use first
-                    selected_sensor_id = random.choice(sensor_ids) if use_multiple_sensors and len(sensor_ids) > 1 else sensor_ids[0]
-                    metadata = {"sensor_id": str(selected_sensor_id)} if selected_sensor_id else {}
-                    # Include kinematics so the DAA system can coast intruder tracks
-                    metadata["current_state"] = {
-                        "speed": float(ground_speeds[i]) if i < len(ground_speeds) else 0.0,
-                        "track": float(headings[i]) if i < len(headings) else 0.0,
-                        "vertical_speed": float(vertical_speeds[i]) if i < len(vertical_speeds) else 0.0,
-                    }
+                        # Assign sensor ID: randomly select from list if multiple sensors, otherwise use first
+                        selected_sensor_id = random.choice(sensor_ids) if use_multiple_sensors and len(sensor_ids) > 1 else sensor_ids[0]
+                        metadata = {"sensor_id": str(selected_sensor_id)} if selected_sensor_id else {}
+                        # Include kinematics so the DAA system can coast intruder tracks
+                        metadata["current_state"] = {
+                            "speed": float(ground_speeds[i]) if i < len(ground_speeds) else 0.0,
+                            "track": float(headings[i]) if i < len(headings) else 0.0,
+                            "vertical_speed": float(vertical_speeds[i]) if i < len(vertical_speeds) else 0.0,
+                        }
 
-                    obs = FlightObservationSchema(
-                        lat_dd=lat,
-                        lon_dd=lon,
-                        altitude_mm=altitude_mm,
-                        traffic_source=0,
-                        source_type=0,
-                        icao_address=acid,
-                        timestamp=timestamp_microseconds,
-                        metadata=metadata,
-                    )
-                    results_by_acid.setdefault(acid, []).append(obs)
+                        obs = FlightObservationSchema(
+                            lat_dd=lat,
+                            lon_dd=lon,
+                            altitude_mm=altitude_mm,
+                            traffic_source=0,
+                            source_type=0,
+                            icao_address=acid,
+                            timestamp=timestamp_microseconds,
+                            metadata=metadata,
+                        )
+                        results_by_acid.setdefault(acid, []).append(obs)
 
-                    logger.debug(f"{acid:>6} lat={lat:.6f} lon={lon:.6f} alt_mm={altitude_mm:.1f}")
+                        logger.debug(f"{acid:>6} lat={lat:.6f} lon={lon:.6f} alt_mm={altitude_mm:.1f}")
 
-            # Flatten dict -> list[FlightObservationSchema] with stable ordering
-            for acid in sorted(results_by_acid.keys()):
-                flight_observations.extend(results_by_acid[acid])
+                # Flatten dict -> list[FlightObservationSchema] with stable ordering
+                for acid in sorted(results_by_acid.keys()):
+                    flight_observations.extend(results_by_acid[acid])
+        finally:
+            if is_temp_scn:
+                Path(scn_path).unlink(missing_ok=True)
 
         # This method modifies the retrieved simulation data by changing the timestamp and adding latency to the observed dataset
         LATENCY_PROBABILITY = 0.1  # 10% chance to have latency issues

--- a/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
+++ b/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
@@ -1,0 +1,308 @@
+"""User-friendly YAML/JSON scenario definition for BlueSky (.scn) files.
+
+Instead of writing raw BlueSky stack commands, users can define scenarios in a
+structured YAML or JSON format and have them converted to .scn files automatically.
+
+Example YAML scenario::
+
+    name: "A1 Head-On Approach"
+    description: "ASTM F3442 Category A1 head-on scenario"
+    display:
+      pan: [53.5200, -113.5750]
+      trails: true
+      reso: false
+      rtf: 10
+    areas:
+      - name: EDM_A1_BOX
+        color: [0, 255, 0]
+        bounds:
+          - [53.5100, -113.6100]
+          - [53.5100, -113.5400]
+          - [53.5300, -113.5400]
+          - [53.5300, -113.6100]
+    aircraft:
+      - callsign: INTA1
+        type: C172
+        lat: 53.5200
+        lon: -113.5500
+        heading: 270
+        altitude_ft: 400
+        speed_kts: 87
+        waypoints:
+          - [53.5200, -113.5750]
+          - [53.5200, -113.6000]
+    hold_time: "00:02:00.00"
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class BlueSkyArea(BaseModel):
+    """A named polygon area displayed in the BlueSky visualizer."""
+
+    name: str = Field(..., description="Name of the area polygon (used in POLY command)")
+    bounds: list[Annotated[list[float], Field(min_length=2, max_length=2)]] = Field(
+        ...,
+        min_length=3,
+        description="List of [lat, lon] coordinate pairs forming the polygon boundary",
+    )
+    color: Annotated[list[int], Field(min_length=3, max_length=3)] = Field(
+        default=[0, 255, 0],
+        description="RGB color for the polygon as [R, G, B] with values 0–255",
+    )
+
+    @field_validator("color")
+    @classmethod
+    def _validate_color(cls, v: list[int]) -> list[int]:
+        for channel in v:
+            if not (0 <= channel <= 255):
+                raise ValueError(f"Color channel value {channel} must be between 0 and 255")
+        return v
+
+
+class BlueSkyDisplaySettings(BaseModel):
+    """Viewport and display configuration for BlueSky."""
+
+    pan: Annotated[list[float], Field(min_length=2, max_length=2)] | None = Field(
+        default=None,
+        description="Center the view on [lat, lon]",
+    )
+    trails: bool = Field(default=True, description="Show aircraft trails")
+    reso: bool = Field(default=False, description="Enable resolution advisories")
+    rtf: int = Field(default=10, ge=1, description="Real-time factor (simulation speed multiplier)")
+
+
+class BlueSkyAircraft(BaseModel):
+    """A single aircraft to be created and flown in the BlueSky scenario."""
+
+    callsign: str = Field(..., description="Aircraft callsign / ACID (e.g. INTA1)")
+    type: str = Field(..., description="Aircraft type code (e.g. C172, B744, P28A)")
+    lat: float = Field(..., ge=-90.0, le=90.0, description="Initial latitude in decimal degrees")
+    lon: float = Field(..., ge=-180.0, le=180.0, description="Initial longitude in decimal degrees")
+    heading: float = Field(..., ge=0.0, le=360.0, description="Initial true heading in degrees")
+    altitude_ft: float = Field(..., ge=0.0, description="Initial altitude in feet (or flight level, e.g. 'FL080' as 8000)")
+    speed_kts: float = Field(..., ge=0.0, description="Initial airspeed in knots")
+    start_time: str = Field(default="00:00:00.00", description="Simulation time to create this aircraft (HH:MM:SS.SS)")
+    waypoints: list[Annotated[list[float], Field(min_length=2, max_length=2)]] = Field(
+        default_factory=list,
+        description="Ordered list of [lat, lon] waypoints for the aircraft to follow",
+    )
+
+    @field_validator("callsign")
+    @classmethod
+    def _validate_callsign(cls, v: str) -> str:
+        v = v.strip().upper()
+        if not v:
+            raise ValueError("callsign must not be empty")
+        return v
+
+    @field_validator("start_time")
+    @classmethod
+    def _validate_time_format(cls, v: str) -> str:
+        parts = v.split(":")
+        if len(parts) != 3:
+            raise ValueError(f"start_time '{v}' must be in HH:MM:SS.SS format")
+        return v
+
+
+class BlueSkyScenarioDefinition(BaseModel):
+    """User-friendly definition of a BlueSky simulation scenario.
+
+    This model can be serialised to/from YAML or JSON and converted to the
+    BlueSky ``.scn`` stack-command format via :meth:`to_scn`.
+    """
+
+    name: str = Field(..., description="Human-readable name for this scenario")
+    description: str = Field(default="", description="Optional longer description of the scenario")
+    display: BlueSkyDisplaySettings = Field(default_factory=BlueSkyDisplaySettings)
+    areas: list[BlueSkyArea] = Field(default_factory=list, description="Polygon areas to display")
+    aircraft: list[BlueSkyAircraft] = Field(..., min_length=1, description="List of aircraft to simulate")
+    hold_time: str = Field(
+        default="00:02:00.00",
+        description="Simulation time at which the HOLD command is issued to stop the run (HH:MM:SS.SS)",
+    )
+
+    @field_validator("hold_time")
+    @classmethod
+    def _validate_hold_time(cls, v: str) -> str:
+        parts = v.split(":")
+        if len(parts) != 3:
+            raise ValueError(f"hold_time '{v}' must be in HH:MM:SS.SS format")
+        return v
+
+    @model_validator(mode="after")
+    def _callsigns_unique(self) -> "BlueSkyScenarioDefinition":
+        seen: set[str] = set()
+        for ac in self.aircraft:
+            if ac.callsign in seen:
+                raise ValueError(f"Duplicate aircraft callsign: {ac.callsign}")
+            seen.add(ac.callsign)
+        return self
+
+    # ------------------------------------------------------------------
+    # Conversion helpers
+    # ------------------------------------------------------------------
+
+    def to_scn(self) -> str:
+        """Render this scenario definition as a BlueSky ``.scn`` file string.
+
+        Returns:
+            str: The complete text content of a BlueSky ``.scn`` file.
+        """
+        lines: list[str] = []
+
+        # Header comment
+        lines.append(f"# {self.name}")
+        if self.description:
+            for desc_line in self.description.splitlines():
+                lines.append(f"# {desc_line}")
+        lines.append("")
+
+        # Polygon areas
+        for area in self.areas:
+            coord_str = " ".join(f"{lat},{lon}" for lat, lon in area.bounds)
+            lines.append(f"00:00:00.00>POLY {area.name} {coord_str}")
+            r, g, b = area.color
+            lines.append(f"00:00:00.00>COLOR {area.name} {r},{g},{b}")
+            lines.append("")
+
+        # Display / viewport settings
+        disp = self.display
+        lines.append(f"00:00:00.00>TRAILS {'ON' if disp.trails else 'OFF'}")
+        lines.append(f"00:00:00.00>RESO {'ON' if disp.reso else 'OFF'}")
+        lines.append(f"00:00:00.00>RTF {disp.rtf}")
+        if disp.pan is not None:
+            lat_pan, lon_pan = disp.pan
+            lines.append(f"00:00:00.00>PAN {lat_pan},{lon_pan}")
+        lines.append("00:00:00.00>-")
+        lines.append("")
+
+        # Aircraft
+        for ac in self.aircraft:
+            # Format altitude: if it's a whole number >= 1000, render as FL
+            alt_str = _format_altitude(ac.altitude_ft)
+            lines.append(f"# {ac.callsign}: {ac.type}, hdg {ac.heading}° alt {alt_str} spd {ac.speed_kts} kts")
+            lines.append(f"{ac.start_time}>CRE {ac.callsign},{ac.type},{ac.lat},{ac.lon},{ac.heading},{ac.altitude_ft},{ac.speed_kts}")
+            for wpt_lat, wpt_lon in ac.waypoints:
+                lines.append(f"{ac.start_time}>{ac.callsign} ADDWPT {wpt_lat},{wpt_lon}")
+            lines.append("")
+
+        # Hold command
+        lines.append(f"{self.hold_time}>HOLD")
+
+        return "\n".join(lines) + "\n"
+
+    def write_scn(self, path: str | Path) -> Path:
+        """Write the rendered ``.scn`` content to *path*.
+
+        Args:
+            path: Destination file path.  Parent directories are created if necessary.
+
+        Returns:
+            Path: The resolved path that was written.
+        """
+        dest = Path(path).expanduser().resolve()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(self.to_scn(), encoding="utf-8")
+        return dest
+
+    def write_temp_scn(self) -> str:
+        """Write the scenario to a temporary ``.scn`` file and return its path.
+
+        The caller is responsible for deleting the file when done (or using a
+        :class:`tempfile.TemporaryDirectory` context).
+
+        Returns:
+            str: Absolute path to the temporary ``.scn`` file.
+        """
+        fd, tmp_path = tempfile.mkstemp(prefix="openutm-bluesky-", suffix=".scn")
+        import os
+
+        os.close(fd)
+        Path(tmp_path).write_text(self.to_scn(), encoding="utf-8")
+        return tmp_path
+
+
+# ------------------------------------------------------------------
+# Factory / loader helpers
+# ------------------------------------------------------------------
+
+
+def load_bluesky_scenario(path: str | Path) -> BlueSkyScenarioDefinition:
+    """Load a :class:`BlueSkyScenarioDefinition` from a YAML or JSON file.
+
+    The file format is detected from the file extension:
+    * ``.yaml`` / ``.yml`` → YAML
+    * ``.json`` → JSON
+
+    Args:
+        path: Path to the YAML or JSON scenario definition file.
+
+    Returns:
+        BlueSkyScenarioDefinition: The parsed scenario definition.
+
+    Raises:
+        ValueError: If the file extension is not recognised.
+        FileNotFoundError: If the file does not exist.
+    """
+    p = Path(path).expanduser().resolve()
+    if not p.exists():
+        raise FileNotFoundError(f"BlueSky scenario file not found: {p}")
+
+    suffix = p.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        with p.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    elif suffix == ".json":
+        with p.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    else:
+        raise ValueError(f"Unsupported file extension '{suffix}' for BlueSky scenario definition. Use .yaml, .yml, or .json")
+
+    return BlueSkyScenarioDefinition.model_validate(data)
+
+
+def resolve_scn_path(config_path: str) -> tuple[str, bool]:
+    """Resolve a config path to a ``.scn`` file path.
+
+    If *config_path* points to a YAML or JSON file, converts it to a temporary
+    ``.scn`` file and returns the temp path along with ``True`` (indicating the
+    caller owns the temp file).
+
+    If *config_path* already points to a ``.scn`` (or any other extension), it
+    is returned unchanged with ``False``.
+
+    Args:
+        config_path: Path to a ``.scn``, ``.yaml``, ``.yml``, or ``.json`` file.
+
+    Returns:
+        tuple[str, bool]: ``(resolved_scn_path, is_temp)`` where *is_temp* is
+        ``True`` when a temporary file was created and should be cleaned up.
+    """
+    suffix = Path(config_path).suffix.lower()
+    if suffix in {".yaml", ".yml", ".json"}:
+        definition = load_bluesky_scenario(config_path)
+        tmp_path = definition.write_temp_scn()
+        return tmp_path, True
+    return config_path, False
+
+
+# ------------------------------------------------------------------
+# Private helpers
+# ------------------------------------------------------------------
+
+
+def _format_altitude(altitude_ft: float) -> str:
+    """Format an altitude value for display in comments."""
+    if altitude_ft >= 1000 and altitude_ft % 100 == 0:
+        fl = int(altitude_ft // 100)
+        return f"FL{fl:03d}"
+    return f"{altitude_ft:.0f} ft"

--- a/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
+++ b/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
@@ -37,16 +37,24 @@ Example YAML scenario::
 from __future__ import annotations
 
 import json
+import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Annotated
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Regex for BlueSky timed stack commands: HH:MM:SS.SS
+# Hours: any non-negative integer; minutes/seconds: 00–59; fractional: exactly 2 digits.
+_BLUESKY_TIME_RE = re.compile(r"^\d+:([0-5]\d):([0-5]\d)\.\d{2}$")
 
 
 class BlueSkyArea(BaseModel):
     """A named polygon area displayed in the BlueSky visualizer."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Name of the area polygon (used in POLY command)")
     bounds: list[Annotated[list[float], Field(min_length=2, max_length=2)]] = Field(
@@ -71,6 +79,8 @@ class BlueSkyArea(BaseModel):
 class BlueSkyDisplaySettings(BaseModel):
     """Viewport and display configuration for BlueSky."""
 
+    model_config = ConfigDict(extra="forbid")
+
     pan: Annotated[list[float], Field(min_length=2, max_length=2)] | None = Field(
         default=None,
         description="Center the view on [lat, lon]",
@@ -83,12 +93,14 @@ class BlueSkyDisplaySettings(BaseModel):
 class BlueSkyAircraft(BaseModel):
     """A single aircraft to be created and flown in the BlueSky scenario."""
 
+    model_config = ConfigDict(extra="forbid")
+
     callsign: str = Field(..., description="Aircraft callsign / ACID (e.g. INTA1)")
     type: str = Field(..., description="Aircraft type code (e.g. C172, B744, P28A)")
     lat: float = Field(..., ge=-90.0, le=90.0, description="Initial latitude in decimal degrees")
     lon: float = Field(..., ge=-180.0, le=180.0, description="Initial longitude in decimal degrees")
     heading: float = Field(..., ge=0.0, le=360.0, description="Initial true heading in degrees")
-    altitude_ft: float = Field(..., ge=0.0, description="Initial altitude in feet (or flight level, e.g. 'FL080' as 8000)")
+    altitude_ft: float = Field(..., ge=0.0, description="Initial altitude in feet")
     speed_kts: float = Field(..., ge=0.0, description="Initial airspeed in knots")
     start_time: str = Field(default="00:00:00.00", description="Simulation time to create this aircraft (HH:MM:SS.SS)")
     waypoints: list[Annotated[list[float], Field(min_length=2, max_length=2)]] = Field(
@@ -107,9 +119,8 @@ class BlueSkyAircraft(BaseModel):
     @field_validator("start_time")
     @classmethod
     def _validate_time_format(cls, v: str) -> str:
-        parts = v.split(":")
-        if len(parts) != 3:
-            raise ValueError(f"start_time '{v}' must be in HH:MM:SS.SS format")
+        if not _BLUESKY_TIME_RE.match(v):
+            raise ValueError(f"start_time '{v}' must be in HH:MM:SS.SS format with minutes and seconds in range 00–59")
         return v
 
 
@@ -119,6 +130,8 @@ class BlueSkyScenarioDefinition(BaseModel):
     This model can be serialised to/from YAML or JSON and converted to the
     BlueSky ``.scn`` stack-command format via :meth:`to_scn`.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Human-readable name for this scenario")
     description: str = Field(default="", description="Optional longer description of the scenario")
@@ -133,9 +146,8 @@ class BlueSkyScenarioDefinition(BaseModel):
     @field_validator("hold_time")
     @classmethod
     def _validate_hold_time(cls, v: str) -> str:
-        parts = v.split(":")
-        if len(parts) != 3:
-            raise ValueError(f"hold_time '{v}' must be in HH:MM:SS.SS format")
+        if not _BLUESKY_TIME_RE.match(v):
+            raise ValueError(f"hold_time '{v}' must be in HH:MM:SS.SS format with minutes and seconds in range 00–59")
         return v
 
     @model_validator(mode="after")
@@ -181,18 +193,21 @@ class BlueSkyScenarioDefinition(BaseModel):
         lines.append(f"00:00:00.00>RTF {disp.rtf}")
         if disp.pan is not None:
             lat_pan, lon_pan = disp.pan
-            lines.append(f"00:00:00.00>PAN {lat_pan},{lon_pan}")
+            lines.append(f"00:00:00.00>PAN {_fmt_coord(lat_pan)},{_fmt_coord(lon_pan)}")
         lines.append("00:00:00.00>-")
         lines.append("")
 
         # Aircraft
         for ac in self.aircraft:
-            # Format altitude: if it's a whole number >= 1000, render as FL
             alt_str = _format_altitude(ac.altitude_ft)
-            lines.append(f"# {ac.callsign}: {ac.type}, hdg {ac.heading}° alt {alt_str} spd {ac.speed_kts} kts")
-            lines.append(f"{ac.start_time}>CRE {ac.callsign},{ac.type},{ac.lat},{ac.lon},{ac.heading},{ac.altitude_ft},{ac.speed_kts}")
+            lines.append(f"# {ac.callsign}: {ac.type}, hdg {_fmt_num(ac.heading)}° alt {alt_str} spd {_fmt_num(ac.speed_kts)} kts")
+            lines.append(
+                f"{ac.start_time}>CRE {ac.callsign},{ac.type},"
+                f"{_fmt_coord(ac.lat)},{_fmt_coord(ac.lon)},"
+                f"{_fmt_num(ac.heading)},{_fmt_num(ac.altitude_ft)},{_fmt_num(ac.speed_kts)}"
+            )
             for wpt_lat, wpt_lon in ac.waypoints:
-                lines.append(f"{ac.start_time}>{ac.callsign} ADDWPT {wpt_lat},{wpt_lon}")
+                lines.append(f"{ac.start_time}>{ac.callsign} ADDWPT {_fmt_coord(wpt_lat)},{_fmt_coord(wpt_lon)}")
             lines.append("")
 
         # Hold command
@@ -224,8 +239,6 @@ class BlueSkyScenarioDefinition(BaseModel):
             str: Absolute path to the temporary ``.scn`` file.
         """
         fd, tmp_path = tempfile.mkstemp(prefix="openutm-bluesky-", suffix=".scn")
-        import os
-
         os.close(fd)
         Path(tmp_path).write_text(self.to_scn(), encoding="utf-8")
         return tmp_path
@@ -306,3 +319,22 @@ def _format_altitude(altitude_ft: float) -> str:
         fl = int(altitude_ft // 100)
         return f"FL{fl:03d}"
     return f"{altitude_ft:.0f} ft"
+
+
+def _fmt_num(v: float) -> str:
+    """Render a float as an integer string when it is a whole number, otherwise as-is.
+
+    This keeps BlueSky stack commands clean: ``270`` instead of ``270.0``.
+    """
+    if v == int(v):
+        return str(int(v))
+    return str(v)
+
+
+def _fmt_coord(v: float) -> str:
+    """Render a latitude or longitude to 4 decimal places.
+
+    This matches the precision convention used in the existing ``.scn`` files
+    in the ``config/`` directory (e.g. ``53.5200,-113.5500``).
+    """
+    return f"{v:.4f}"

--- a/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
+++ b/src/openutm_verification/core/clients/air_traffic/bluesky_scenario.py
@@ -180,7 +180,9 @@ class BlueSkyScenarioDefinition(BaseModel):
 
         # Polygon areas
         for area in self.areas:
-            coord_str = " ".join(f"{lat},{lon}" for lat, lon in area.bounds)
+            coord_str = " ".join(
+                f"{_fmt_coord(lat)},{_fmt_coord(lon)}" for lat, lon in area.bounds
+            )
             lines.append(f"00:00:00.00>POLY {area.name} {coord_str}")
             r, g, b = area.color
             lines.append(f"00:00:00.00>COLOR {area.name} {r},{g},{b}")

--- a/tests/test_bluesky_scenario.py
+++ b/tests/test_bluesky_scenario.py
@@ -1,0 +1,349 @@
+"""Tests for the BlueSky YAML scenario definition feature (issue #78)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openutm_verification.core.clients.air_traffic.bluesky_scenario import (
+    BlueSkyAircraft,
+    BlueSkyArea,
+    BlueSkyScenarioDefinition,
+    load_bluesky_scenario,
+    resolve_scn_path,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_SCENARIO_DATA: dict = {
+    "name": "Test Scenario",
+    "aircraft": [
+        {
+            "callsign": "AC001",
+            "type": "C172",
+            "lat": 53.5200,
+            "lon": -113.5500,
+            "heading": 270,
+            "altitude_ft": 400,
+            "speed_kts": 87,
+        }
+    ],
+}
+
+FULL_SCENARIO_DATA: dict = {
+    "name": "A1 Head-On Approach",
+    "description": "ASTM F3442 Category A1 scenario",
+    "display": {
+        "pan": [53.5200, -113.5750],
+        "trails": True,
+        "reso": False,
+        "rtf": 10,
+    },
+    "areas": [
+        {
+            "name": "EDM_A1_BOX",
+            "color": [0, 255, 0],
+            "bounds": [
+                [53.5100, -113.6100],
+                [53.5100, -113.5400],
+                [53.5300, -113.5400],
+                [53.5300, -113.6100],
+            ],
+        }
+    ],
+    "aircraft": [
+        {
+            "callsign": "INTA1",
+            "type": "C172",
+            "lat": 53.5200,
+            "lon": -113.5500,
+            "heading": 270,
+            "altitude_ft": 400,
+            "speed_kts": 87,
+            "start_time": "00:00:00.00",
+            "waypoints": [
+                [53.5200, -113.5750],
+                [53.5200, -113.6000],
+            ],
+        }
+    ],
+    "hold_time": "00:02:00.00",
+}
+
+
+# ---------------------------------------------------------------------------
+# Model validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestBlueSkyArea:
+    def test_valid_area(self) -> None:
+        area = BlueSkyArea(
+            name="BOX",
+            bounds=[[53.0, -113.0], [53.0, -112.0], [54.0, -112.0]],
+        )
+        assert area.name == "BOX"
+        assert area.color == [0, 255, 0]
+
+    def test_invalid_color_channel(self) -> None:
+        with pytest.raises(ValueError, match="Color channel value"):
+            BlueSkyArea(
+                name="BOX",
+                bounds=[[53.0, -113.0], [53.0, -112.0], [54.0, -112.0]],
+                color=[0, 256, 0],
+            )
+
+    def test_too_few_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            BlueSkyArea(name="BOX", bounds=[[53.0, -113.0], [53.0, -112.0]])
+
+
+class TestBlueSkyAircraft:
+    def test_callsign_uppercased(self) -> None:
+        ac = BlueSkyAircraft(
+            callsign="ac001",
+            type="C172",
+            lat=53.0,
+            lon=-113.0,
+            heading=270,
+            altitude_ft=400,
+            speed_kts=87,
+        )
+        assert ac.callsign == "AC001"
+
+    def test_invalid_time_format(self) -> None:
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyAircraft(
+                callsign="AC001",
+                type="C172",
+                lat=53.0,
+                lon=-113.0,
+                heading=270,
+                altitude_ft=400,
+                speed_kts=87,
+                start_time="invalid",
+            )
+
+    def test_heading_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            BlueSkyAircraft(
+                callsign="AC001",
+                type="C172",
+                lat=53.0,
+                lon=-113.0,
+                heading=400,  # > 360
+                altitude_ft=400,
+                speed_kts=87,
+            )
+
+
+class TestBlueSkyScenarioDefinition:
+    def test_minimal_valid(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
+        assert scenario.name == "Test Scenario"
+        assert len(scenario.aircraft) == 1
+        assert scenario.hold_time == "00:02:00.00"
+
+    def test_full_valid(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        assert scenario.name == "A1 Head-On Approach"
+        assert len(scenario.areas) == 1
+        assert scenario.display.pan == [53.5200, -113.5750]
+
+    def test_duplicate_callsigns_rejected(self) -> None:
+        data = {
+            "name": "Dup",
+            "aircraft": [
+                {"callsign": "AC001", "type": "C172", "lat": 53.0, "lon": -113.0, "heading": 0, "altitude_ft": 400, "speed_kts": 87},
+                {"callsign": "AC001", "type": "B744", "lat": 54.0, "lon": -114.0, "heading": 0, "altitude_ft": 400, "speed_kts": 200},
+            ],
+        }
+        with pytest.raises(ValueError, match="Duplicate aircraft callsign"):
+            BlueSkyScenarioDefinition.model_validate(data)
+
+    def test_no_aircraft_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            BlueSkyScenarioDefinition.model_validate({"name": "Empty", "aircraft": []})
+
+
+# ---------------------------------------------------------------------------
+# SCN rendering tests
+# ---------------------------------------------------------------------------
+
+
+class TestToScn:
+    def test_minimal_scn_contains_cre_and_hold(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "CRE AC001,C172" in scn
+        assert "HOLD" in scn
+
+    def test_waypoints_rendered(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "INTA1 ADDWPT 53.52,-113.575" in scn
+        assert "INTA1 ADDWPT 53.52,-113.6" in scn
+
+    def test_poly_area_rendered(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "POLY EDM_A1_BOX" in scn
+        assert "COLOR EDM_A1_BOX 0,255,0" in scn
+
+    def test_display_settings_rendered(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "TRAILS ON" in scn
+        assert "RESO OFF" in scn
+        assert "RTF 10" in scn
+        assert "PAN 53.52,-113.575" in scn
+
+    def test_header_comment(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert scn.startswith("# A1 Head-On Approach")
+
+    def test_staggered_start_time(self) -> None:
+        data = {
+            "name": "Staggered",
+            "aircraft": [
+                {
+                    "callsign": "INTB",
+                    "type": "B206",
+                    "lat": 53.52,
+                    "lon": -113.55,
+                    "heading": 0,
+                    "altitude_ft": 492,
+                    "speed_kts": 78,
+                    "start_time": "00:00:20.00",
+                }
+            ],
+        }
+        scn = BlueSkyScenarioDefinition.model_validate(data).to_scn()
+        assert "00:00:20.00>CRE INTB,B206" in scn
+
+    def test_hold_time_in_scn(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "00:02:00.00>HOLD" in scn
+
+    def test_write_scn_creates_file(self, tmp_path: Path) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
+        dest = tmp_path / "out.scn"
+        returned = scenario.write_scn(dest)
+        assert returned == dest
+        assert dest.exists()
+        assert "CRE AC001" in dest.read_text()
+
+    def test_write_temp_scn(self) -> None:
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
+        tmp = scenario.write_temp_scn()
+        p = Path(tmp)
+        try:
+            assert p.exists()
+            assert p.suffix == ".scn"
+            assert "CRE AC001" in p.read_text()
+        finally:
+            p.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# load_bluesky_scenario tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBlueSkyScenario:
+    def test_load_yaml_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.yaml"
+        f.write_text(yaml.dump(FULL_SCENARIO_DATA))
+        loaded = load_bluesky_scenario(f)
+        assert loaded.name == "A1 Head-On Approach"
+
+    def test_load_yml_extension(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.yml"
+        f.write_text(yaml.dump(MINIMAL_SCENARIO_DATA))
+        loaded = load_bluesky_scenario(f)
+        assert loaded.name == "Test Scenario"
+
+    def test_load_json_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.json"
+        f.write_text(json.dumps(FULL_SCENARIO_DATA))
+        loaded = load_bluesky_scenario(f)
+        assert loaded.name == "A1 Head-On Approach"
+
+    def test_unsupported_extension_raises(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.txt"
+        f.write_text("content")
+        with pytest.raises(ValueError, match="Unsupported file extension"):
+            load_bluesky_scenario(f)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_bluesky_scenario(tmp_path / "nonexistent.yaml")
+
+
+# ---------------------------------------------------------------------------
+# resolve_scn_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScnPath:
+    def test_scn_file_passthrough(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.scn"
+        f.write_text("00:00:00.00>CRE AC001")
+        path, is_temp = resolve_scn_path(str(f))
+        assert path == str(f)
+        assert is_temp is False
+
+    def test_yaml_file_creates_temp_scn(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.yaml"
+        f.write_text(yaml.dump(MINIMAL_SCENARIO_DATA))
+        path, is_temp = resolve_scn_path(str(f))
+        p = Path(path)
+        try:
+            assert p.suffix == ".scn"
+            assert is_temp is True
+            assert p.exists()
+            assert "CRE AC001" in p.read_text()
+        finally:
+            p.unlink(missing_ok=True)
+
+    def test_json_file_creates_temp_scn(self, tmp_path: Path) -> None:
+        f = tmp_path / "scenario.json"
+        f.write_text(json.dumps(MINIMAL_SCENARIO_DATA))
+        path, is_temp = resolve_scn_path(str(f))
+        p = Path(path)
+        try:
+            assert p.suffix == ".scn"
+            assert is_temp is True
+        finally:
+            p.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Integration: round-trip YAML -> .scn for the bundled example files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "yaml_path",
+    [
+        Path(__file__).parent.parent / "config" / "edmonton" / "bluesky_a1_head_on.yaml",
+        Path(__file__).parent.parent / "config" / "edmonton" / "bluesky_b2_staggered.yaml",
+    ],
+    ids=["a1_head_on", "b2_staggered"],
+)
+def test_bundled_yaml_examples_round_trip(yaml_path: Path) -> None:
+    """Ensure the bundled YAML example files parse and render without errors."""
+    assert yaml_path.exists(), f"Example YAML file not found: {yaml_path}"
+    scenario = load_bluesky_scenario(yaml_path)
+    scn_text = scenario.to_scn()
+    # At minimum, every aircraft callsign must appear in the rendered file
+    for ac in scenario.aircraft:
+        assert ac.callsign in scn_text
+    assert "HOLD" in scn_text

--- a/tests/test_bluesky_scenario.py
+++ b/tests/test_bluesky_scenario.py
@@ -129,6 +129,45 @@ class TestBlueSkyAircraft:
                 start_time="invalid",
             )
 
+    def test_start_time_out_of_range_minutes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyAircraft(
+                callsign="AC001",
+                type="C172",
+                lat=53.0,
+                lon=-113.0,
+                heading=270,
+                altitude_ft=400,
+                speed_kts=87,
+                start_time="00:99:00.00",  # minutes out of range
+            )
+
+    def test_start_time_out_of_range_seconds_rejected(self) -> None:
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyAircraft(
+                callsign="AC001",
+                type="C172",
+                lat=53.0,
+                lon=-113.0,
+                heading=270,
+                altitude_ft=400,
+                speed_kts=87,
+                start_time="00:00:60.00",  # seconds out of range
+            )
+
+    def test_start_time_non_numeric_rejected(self) -> None:
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyAircraft(
+                callsign="AC001",
+                type="C172",
+                lat=53.0,
+                lon=-113.0,
+                heading=270,
+                altitude_ft=400,
+                speed_kts=87,
+                start_time="00:00:xx.00",
+            )
+
     def test_heading_out_of_range(self) -> None:
         with pytest.raises(ValueError):
             BlueSkyAircraft(
@@ -170,6 +209,43 @@ class TestBlueSkyScenarioDefinition:
         with pytest.raises(ValueError):
             BlueSkyScenarioDefinition.model_validate({"name": "Empty", "aircraft": []})
 
+    def test_hold_time_out_of_range_minutes_rejected(self) -> None:
+        data = dict(MINIMAL_SCENARIO_DATA)
+        data["hold_time"] = "00:99:00.00"  # minutes out of range
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyScenarioDefinition.model_validate(data)
+
+    def test_hold_time_invalid_format_rejected(self) -> None:
+        data = dict(MINIMAL_SCENARIO_DATA)
+        data["hold_time"] = "2minutes"
+        with pytest.raises(ValueError, match="HH:MM:SS.SS"):
+            BlueSkyScenarioDefinition.model_validate(data)
+
+    def test_extra_fields_rejected(self) -> None:
+        data = dict(MINIMAL_SCENARIO_DATA)
+        data["unknown_field"] = "typo_value"
+        with pytest.raises(ValueError):
+            BlueSkyScenarioDefinition.model_validate(data)
+
+    def test_extra_fields_in_aircraft_rejected(self) -> None:
+        data = {
+            "name": "Test",
+            "aircraft": [
+                {
+                    "callsign": "AC001",
+                    "type": "C172",
+                    "lat": 53.0,
+                    "lon": -113.0,
+                    "heading": 270,
+                    "altitude_ft": 400,
+                    "speed_kts": 87,
+                    "typo_field": "oops",
+                }
+            ],
+        }
+        with pytest.raises(ValueError):
+            BlueSkyScenarioDefinition.model_validate(data)
+
 
 # ---------------------------------------------------------------------------
 # SCN rendering tests
@@ -186,8 +262,8 @@ class TestToScn:
     def test_waypoints_rendered(self) -> None:
         scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
         scn = scenario.to_scn()
-        assert "INTA1 ADDWPT 53.52,-113.575" in scn
-        assert "INTA1 ADDWPT 53.52,-113.6" in scn
+        assert "INTA1 ADDWPT 53.5200,-113.5750" in scn
+        assert "INTA1 ADDWPT 53.5200,-113.6000" in scn
 
     def test_poly_area_rendered(self) -> None:
         scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
@@ -201,7 +277,7 @@ class TestToScn:
         assert "TRAILS ON" in scn
         assert "RESO OFF" in scn
         assert "RTF 10" in scn
-        assert "PAN 53.52,-113.575" in scn
+        assert "PAN 53.5200,-113.5750" in scn
 
     def test_header_comment(self) -> None:
         scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
@@ -227,10 +303,21 @@ class TestToScn:
         scn = BlueSkyScenarioDefinition.model_validate(data).to_scn()
         assert "00:00:20.00>CRE INTB,B206" in scn
 
-    def test_hold_time_in_scn(self) -> None:
-        scenario = BlueSkyScenarioDefinition.model_validate(FULL_SCENARIO_DATA)
+    def test_cre_command_integer_formatting(self) -> None:
+        """Whole-number heading/altitude/speed must not render as floats (e.g. 270 not 270.0)."""
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
         scn = scenario.to_scn()
-        assert "00:02:00.00>HOLD" in scn
+        # Should contain integer values, not float representations
+        assert "CRE AC001,C172,53.5200,-113.5500,270,400,87" in scn
+        assert "270.0" not in scn
+        assert "400.0" not in scn
+        assert "87.0" not in scn
+
+    def test_cre_command_coord_precision(self) -> None:
+        """Lat/lon in CRE command must use 4 decimal places."""
+        scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)
+        scn = scenario.to_scn()
+        assert "53.5200,-113.5500" in scn
 
     def test_write_scn_creates_file(self, tmp_path: Path) -> None:
         scenario = BlueSkyScenarioDefinition.model_validate(MINIMAL_SCENARIO_DATA)


### PR DESCRIPTION
Implement #78 

- Introduced new YAML scenario files for A1 Head-On Approach and B2 Staggered Arrival scenarios in the Edmonton configuration.
- Implemented a new Python module for user-friendly BlueSky scenario definitions, allowing scenarios to be defined in YAML or JSON format and converted to .scn files.
- Added validation for scenario components including areas, aircraft, and display settings using Pydantic models.
- Created comprehensive unit tests for scenario validation, rendering, and loading from files, ensuring robust functionality.
- Included integration tests for bundled example YAML files to verify round-trip conversion to .scn format.